### PR TITLE
Implement#1/register page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,34 +10,11 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <title>React App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -10,7 +10,7 @@ import { JWT_TOKEN_KEY } from "./constants";
 // Using memory for caching queries
 // createHttpLink that returns an apollo link
 const link = createHttpLink({
-  uri: "http://localhost:4000",
+  uri: "http://localhost:4000/graphql",
 });
 
 const authLink = setContext(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { AuthProvider } from "./context/auth";
 import { BrowserRouter as Router, Route } from "react-router-dom";
 import { Home, Login, Register } from "./pages";
 import { AuthRoute } from "./utils/AuthRoute";
+import "semantic-ui-css/semantic.min.css";
+
 const App = () => {
   return (
     <AuthProvider>

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -4,9 +4,3 @@ export type FormType = {
     email?: string,
     confirmPassword?: string
 }
-
-export type UserData = {
-    data: {
-        register: User;
-    };
-}

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -1,0 +1,12 @@
+export type FormType = {
+    username: string,
+    password: string,
+    email?: string,
+    confirmPassword?: string
+}
+
+export type UserData = {
+    data: {
+        register: User;
+    };
+}

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -1,14 +1,15 @@
 import { createContext, useReducer } from "react";
 import jwtDecode from "jwt-decode";
 import { JWT_TOKEN_KEY } from "../constants";
+import { User } from "../graphql/schemas";
 
 // This is the expected result from jwtDecode
-interface Jwtitem {
+interface Jwtitem extends User{
   exp: number;
 }
 interface State {
   user: Jwtitem | null;
-  login: (userData: { token: any }) => void;
+  login: (userData: User) => void;
   logout: () => void;
 }
 // This is like a replacement of Redux

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -2,20 +2,22 @@ import { createContext, useReducer } from "react";
 import jwtDecode from "jwt-decode";
 import { JWT_TOKEN_KEY } from "../constants";
 import { User } from "../graphql/schemas";
+import { UserData } from "../common/types";
 
 // This is the expected result from jwtDecode
-interface Jwtitem extends User{
+interface Jwtitem extends User {
   exp: number;
 }
 interface State {
   user: Jwtitem | null;
-  login: (userData: User) => void;
+  login: (userData: UserData) => void;
   logout: () => void;
 }
+
 // This is like a replacement of Redux
 const initState: State = {
   user: null,
-  login: (userData) => {},
+  login: (userData: UserData) => {},
   logout: () => {},
 };
 
@@ -29,7 +31,7 @@ if (localStorage.getItem(JWT_TOKEN_KEY)) {
 
 const AuthContext = createContext({
   user: null,
-  login: (userData) => {},
+  login: (userData: UserData) => {},
   logout: () => {},
 } as State);
 
@@ -46,8 +48,8 @@ function authReducer(state: State, action: { type: string; payload?: any }) {
 
 function AuthProvider(props: Object) {
   const [state, dispatch] = useReducer(authReducer, initState);
-  const login = (userData: { token: any }) => {
-    localStorage.setItem(JWT_TOKEN_KEY, userData.token);
+  const login = (userData: UserData) => {
+    localStorage.setItem(JWT_TOKEN_KEY, userData.data.register.token || "");
     dispatch({
       type: "LOGIN",
       payload: userData,

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -2,7 +2,7 @@ import { createContext, useReducer } from "react";
 import jwtDecode from "jwt-decode";
 import { JWT_TOKEN_KEY } from "../constants";
 import { User } from "../graphql/schemas";
-import { UserData } from "../common/types";
+import { UserMutation } from "../graphql/mutations";
 
 // This is the expected result from jwtDecode
 interface Jwtitem extends User {
@@ -10,14 +10,14 @@ interface Jwtitem extends User {
 }
 interface State {
   user: Jwtitem | null;
-  login: (userData: UserData) => void;
+  login: (userData: UserMutation) => void;
   logout: () => void;
 }
 
 // This is like a replacement of Redux
 const initState: State = {
   user: null,
-  login: (userData: UserData) => {},
+  login: (userData: UserMutation) => {},
   logout: () => {},
 };
 
@@ -31,7 +31,7 @@ if (localStorage.getItem(JWT_TOKEN_KEY)) {
 
 const AuthContext = createContext({
   user: null,
-  login: (userData: UserData) => {},
+  login: (userData: UserMutation) => {},
   logout: () => {},
 } as State);
 
@@ -48,7 +48,7 @@ function authReducer(state: State, action: { type: string; payload?: any }) {
 
 function AuthProvider(props: Object) {
   const [state, dispatch] = useReducer(authReducer, initState);
-  const login = (userData: UserData) => {
+  const login = (userData: UserMutation) => {
     localStorage.setItem(JWT_TOKEN_KEY, userData.data.register.token || "");
     dispatch({
       type: "LOGIN",

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -1,0 +1,24 @@
+import gql from "graphql-tag";
+export const REGISTER_USER_MUTATION = gql`
+  mutation register(
+    $username: String!
+    $email: String!
+    $password: String!
+    $confirmPassword: String!
+  ) {
+    register(
+      username: $username
+      email: $email
+      password: $password
+      confirmPassword: $confirmPassword
+    ) {
+      id
+      token
+      profile {
+        totalCost
+        totalPrice
+        totalAddedItems
+      }
+    }
+  }
+`;

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -1,6 +1,14 @@
 import gql from "graphql-tag";
+import { User } from "./schemas";
+
+export type UserMutation = {
+  data: {
+    register: User;
+  };
+};
+
 export const REGISTER_USER_MUTATION = gql`
-  mutation register(
+  mutation (
     $username: String!
     $email: String!
     $password: String!
@@ -20,5 +28,11 @@ export const REGISTER_USER_MUTATION = gql`
         totalAddedItems
       }
     }
+  }
+`;
+
+export const LOGIN_USER_MUTATION = gql`
+  mutation ($username: String!, $password: String!) {
+    login
   }
 `;

--- a/src/graphql/schemas.ts
+++ b/src/graphql/schemas.ts
@@ -1,0 +1,24 @@
+export interface UserProfile {
+  totalCost?: number;
+  totalPrice?: number;
+  totalAddedItems?: number;
+  createdAt?: String;
+}
+
+export interface Item {
+  id: string | any;
+  name: string;
+  price: number;
+  cost: number;
+  createdAt: string;
+  username: string;
+}
+
+export interface User {
+  id: string | any;
+  username: string;
+  token: string;
+  createdAt: string;
+  items?: [Item];
+  profile?: UserProfile;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,18 @@
+:root {
+  --main-background-color: #abcabc;
+}
+
+#root,
+body {
+  height: 100%;
+  width: 100%;
+  background-color: var(--main-background-color);
+}
+
+#root > .grid {
+  height: 100%;
+}
+
+.column {
+  max-width: 30rem;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import ReactDOM from "react-dom";
 import ApolloProvider from "./ApolloProvider";
+import "./index.css";
 
 ReactDOM.render(ApolloProvider, document.getElementById("root"));

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,3 @@
+const Home = (props) => {};
+
+export { Home };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext } from "react";
-import { Redirect } from "react-router";
+import { Redirect } from "react-router-dom";
 import { AuthContext } from "../context/auth";
 
 const Home = () => {

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -4,7 +4,7 @@ import { useMutation } from "@apollo/client";
 import { AuthContext } from "../context/auth";
 import { REGISTER_USER_MUTATION } from "../graphql/mutations";
 import { OnForm } from "../utils/hooks";
-import { UserData } from "../common/types";
+import { UserMutation } from "../graphql/mutations";
 
 const Register = (props: any) => {
   const initState = {
@@ -27,7 +27,7 @@ const Register = (props: any) => {
 
   const [register, { loading }] = useMutation(REGISTER_USER_MUTATION, {
     update: (_, result) => {
-      context.login(result as UserData);
+      context.login(result as UserMutation);
       props.history.push("/");
     },
     onError: (err) => {

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useContext } from "react";
+import { useState, useContext } from "react";
 import { Button, Container, Form } from "semantic-ui-react";
 import { useMutation } from "@apollo/client";
 import { AuthContext } from "../context/auth";
-import { User } from "../graphql/schemas";
 import { REGISTER_USER_MUTATION } from "../graphql/mutations";
+import { OnForm } from "../utils/hooks";
+import { UserData } from "../common/types";
 
 const Register = (props: any) => {
   const initState = {
@@ -12,6 +13,9 @@ const Register = (props: any) => {
     password: "",
     confirmPassword: "",
   };
+
+  const { values, onChange, onSubmit } = OnForm(registerUser, initState);
+
   type ErrorsInitState = {
     username: string | null;
     email: string | null;
@@ -19,30 +23,15 @@ const Register = (props: any) => {
     confirmPassword: string | null;
   };
   const context = useContext(AuthContext);
-  const [values, setValues] = useState(initState);
   const [errors, setErrors] = useState({} as ErrorsInitState);
 
-  const handleOnSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    registerUser();
-  };
-  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValues({
-      ...values,
-      [e.target.name]: e.target.value,
-    });
-  };
-
   const [register, { loading }] = useMutation(REGISTER_USER_MUTATION, {
-    update: (proxy, result) => {
-      console.log(result);
-      context.login(result as User);
+    update: (_, result) => {
+      context.login(result as UserData);
       props.history.push("/");
     },
     onError: (err) => {
-      console.log(err);
       const errs = err.graphQLErrors[0].extensions?.exception.errors;
-      console.log(errs);
       setErrors(errs);
     },
     variables: values,
@@ -53,57 +42,73 @@ const Register = (props: any) => {
   }
 
   return (
-    <Container className="form-container">
-      <Form
-        onSubmit={handleOnSubmit}
-        noValidate
-        className={loading ? "loading" : ""}
-      >
-        <h1>Register Page</h1>
-        <Form.Input
-          label="Username"
-          name="username"
-          onChange={handleOnChange}
-          value={values.username}
-          error={errors.username ? true : false}
-        />
-
-        <Form.Input
-          label="Email"
-          name="email"
-          onChange={handleOnChange}
-          value={values.email}
-          error={errors.email ? true : false}
-        />
-        <Form.Input
-          label="Password"
-          name="password"
-          onChange={handleOnChange}
-          value={values.password}
-          error={errors.password ? true : false}
-          type="password"
-        />
-        <Form.Input
-          label="Confirm Password"
-          onChange={handleOnChange}
-          name="confirmPassword"
-          value={values.confirmPassword}
-          type="password"
-          error={errors.confirmPassword ? true : false}
-        />
-        <Button type="submit" primary>
-          Register
-        </Button>
-      </Form>
-      {Object.keys(errors).length > 0 && (
-        <div className="ui error message">
-          <ul className="list">
-            {Object.values(errors).map((error: any) => (
-              <li key={error}>{error}</li>
-            ))}
-          </ul>
+    <Container className="middle aligned center aligned grid">
+      <div className="column">
+        <h2 className="ui header">
+          <div className="content">Register a new account</div>
+        </h2>
+        <Form
+          onSubmit={onSubmit}
+          noValidate
+          className={"ui large form " + (loading ? "loading" : "")}
+        >
+          <div className="ui stacked segment">
+            <Form.Input
+              placeholder="Username"
+              name="username"
+              onChange={onChange}
+              value={values.username}
+              error={errors.username ? true : false}
+              iconPosition="left"
+              icon={<i className="user icon" />}
+            />
+            <Form.Input
+              placeholder="Email"
+              name="email"
+              onChange={onChange}
+              value={values.email}
+              error={errors.email ? true : false}
+              iconPosition="left"
+              icon={<i className="mail icon" />}
+            />
+            <Form.Input
+              placeholder="Password"
+              name="password"
+              onChange={onChange}
+              value={values.password}
+              error={errors.password ? true : false}
+              type="password"
+              iconPosition="left"
+              icon={<i className="lock icon" />}
+            />
+            <Form.Input
+              onChange={onChange}
+              name="confirmPassword"
+              value={values.confirmPassword}
+              type="password"
+              error={errors.confirmPassword ? true : false}
+              placeholder="Confirm Password"
+              iconPosition="left"
+              icon={<i className="lock icon" />}
+            />
+            <Button fluid type="submit" primary className="button">
+              Register
+            </Button>
+          </div>
+        </Form>
+        {Object.keys(errors).length > 0 && (
+          <div className="ui error message">
+            <ul className="list">
+              {Object.values(errors).map((error: any) => (
+                <li key={error}>{error}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <div className="ui message">
+          Have an account already? <a href="/login"> Sign in!</a>
         </div>
-      )}
+      </div>
     </Container>
   );
 };

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,5 +1,111 @@
-const Register = () => {
-  return <div>Register page</div>;
+import React, { useState, useContext } from "react";
+import { Button, Container, Form } from "semantic-ui-react";
+import { useMutation } from "@apollo/client";
+import { AuthContext } from "../context/auth";
+import { User } from "../graphql/schemas";
+import { REGISTER_USER_MUTATION } from "../graphql/mutations";
+
+const Register = (props: any) => {
+  const initState = {
+    username: "",
+    email: "",
+    password: "",
+    confirmPassword: "",
+  };
+  type ErrorsInitState = {
+    username: string | null;
+    email: string | null;
+    password: string | null;
+    confirmPassword: string | null;
+  };
+  const context = useContext(AuthContext);
+  const [values, setValues] = useState(initState);
+  const [errors, setErrors] = useState({} as ErrorsInitState);
+
+  const handleOnSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    registerUser();
+  };
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValues({
+      ...values,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  const [register, { loading }] = useMutation(REGISTER_USER_MUTATION, {
+    update: (proxy, result) => {
+      console.log(result);
+      context.login(result as User);
+      props.history.push("/");
+    },
+    onError: (err) => {
+      console.log(err);
+      const errs = err.graphQLErrors[0].extensions?.exception.errors;
+      console.log(errs);
+      setErrors(errs);
+    },
+    variables: values,
+  });
+
+  function registerUser() {
+    register();
+  }
+
+  return (
+    <Container className="form-container">
+      <Form
+        onSubmit={handleOnSubmit}
+        noValidate
+        className={loading ? "loading" : ""}
+      >
+        <h1>Register Page</h1>
+        <Form.Input
+          label="Username"
+          name="username"
+          onChange={handleOnChange}
+          value={values.username}
+          error={errors.username ? true : false}
+        />
+
+        <Form.Input
+          label="Email"
+          name="email"
+          onChange={handleOnChange}
+          value={values.email}
+          error={errors.email ? true : false}
+        />
+        <Form.Input
+          label="Password"
+          name="password"
+          onChange={handleOnChange}
+          value={values.password}
+          error={errors.password ? true : false}
+          type="password"
+        />
+        <Form.Input
+          label="Confirm Password"
+          onChange={handleOnChange}
+          name="confirmPassword"
+          value={values.confirmPassword}
+          type="password"
+          error={errors.confirmPassword ? true : false}
+        />
+        <Button type="submit" primary>
+          Register
+        </Button>
+      </Form>
+      {Object.keys(errors).length > 0 && (
+        <div className="ui error message">
+          <ul className="list">
+            {Object.values(errors).map((error: any) => (
+              <li key={error}>{error}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </Container>
+  );
 };
 
 export { Register };

--- a/src/utils/AuthRoute.tsx
+++ b/src/utils/AuthRoute.tsx
@@ -2,7 +2,7 @@ import { Route, Redirect, RouteProps } from "react-router-dom";
 import { AuthContext } from "../context/auth";
 import React, { useContext } from "react";
 
-type AuthRouteProps = {
+interface AuthRouteProps extends RouteProps {
   component: React.FC<RouteProps>;
   rest?: any;
 };

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,0 +1,22 @@
+import React, { useState } from "react"
+import { FormType } from "../common/types";
+
+function OnForm(callback: Function, initState: FormType) {
+    const [values, setValues] = useState(initState);
+    const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setValues({ ...values, [e.target.name]: e.target.value });
+    };
+    const onSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        callback();
+    };
+    return {
+        onChange,
+        onSubmit,
+        values
+    }
+}
+
+export {
+    OnForm
+}


### PR DESCRIPTION
The register page is pretty much the template from Semantic UI. Also, I'm adding GraphQL Schemas, and also moving mutations and queries into their own file instead of having it all on each page, separately. Queries will be pretty useful to have on a single file when we deal with proxy and local storage cache as well.